### PR TITLE
feat: add new endpoint - /logout

### DIFF
--- a/express-session.d.ts
+++ b/express-session.d.ts
@@ -1,6 +1,6 @@
 declare module "express-session" {
     interface SessionData {
-        user: string;
+        user: string | null;
     }
 }
 export { };

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@ import helmet from "helmet";
 import { plantsRouter } from "./handlers/plants/plants";
 import { errorHandler } from "./middleware/error";
 import { notFoundHandler } from "./middleware/not-found";
-import { authRouter } from "./handlers/authentication/login";
+import { authRouter } from "./handlers/authentication/authentication";
 import { userRouter } from "./handlers/users/user";
 
 import swaggerUI from "swagger-ui-express"

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,6 +1,8 @@
 import { Users } from "../xata";
 
-export type StatusCodes = 200 | 400 | 402 | 404 | 500;
+// 401 - Unauthorized
+// 403 Forbidden
+export type StatusCodes = 200 | 400 | 402 | 401 | 404 | 500;
 
 export interface ApiResponse {
     status: StatusCodes,

--- a/src/handlers/authentication/authentication.test.ts
+++ b/src/handlers/authentication/authentication.test.ts
@@ -84,7 +84,7 @@ describe("POST /login", () => {
       expect(response.body.auth).exist
     });
 
-    it("and it has an invalid hash, return 402", async () => {
+    it("and it has an invalid hash, return 401", async () => {
       getFirst.mockResolvedValue({
         ...MOCK_EXISTING_USER,
         hash: "too_small",
@@ -92,8 +92,8 @@ describe("POST /login", () => {
       const response = await request(app)
         .post("/api/login")
         .send(MOCK_USER_CREDENTIALS);
-      expect(response.statusCode).toBe(402);
-      expect(response.body.error.message).toContain("User has invalid hash");
+      expect(response.statusCode).toBe(401);
+      expect(response.body.error.message).toContain("Unauthorized");
     });
   });
 
@@ -115,3 +115,13 @@ describe("POST /login", () => {
 
   });
 });
+
+
+describe("GET /logout", () => {
+  it("should remove user session and return 302", async () => {
+    const response = await request(app).get("/api/logout");
+
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe("http://localhost:4321/sign-in");
+  });
+})


### PR DESCRIPTION
What?
- added a new endpoint `/logout` with GET method which will remove the user's session.
- once the session has been removed, the request will response with 302 HTTP code and redirect to /sign-in page